### PR TITLE
Clarify that the value being set is the count

### DIFF
--- a/Chapters/Counter/Exo-Counter.pillar
+++ b/Chapters/Counter/Exo-Counter.pillar
@@ -275,7 +275,7 @@ Therefore at the instance side, you should create a protocol ==initialization==,
 
 [[[
 Counter >> initialize
-  "set the initial value of the value to 0"
+  "set the initial value of the count to 0"
   ...
   Fill me please!!!
 ]]]


### PR DESCRIPTION
The initializer comment says "set the initial _value of the value_ to 0". "Value of the value" is a bit hard to understand. Since the value being referred to is the `count` instance variable, I clarified it to say "value of the count"