### PR TITLE
Fix warnings in Counter >> printOn:

### DIFF
--- a/Chapters/Counter/Exo-Counter.pillar
+++ b/Chapters/Counter/Exo-Counter.pillar
@@ -357,7 +357,8 @@ We would like to get a much richer information for example knowing the counter v
 [[[
 Counter >> printOn: aStream
    super printOn: aStream.
-   aStream nextPutAll: ' with value: ', count printString.
+   aStream nextPutAll: ' with value: '.
+   aStream print: count
 ]]]
 
 Note that the method ==printOn:== is used when you print an object using print it (See Figure *@figBetterDescription*) or click on ==self== in an inspector.


### PR DESCRIPTION
When implementing Counter >> printOn with the code in the book, as of today Pharo 80 gives me the following warnings:

- [printString] No printString inside printOn
- Use cascaded nextPutAll:'s instead of #, in #nextPutAll:

I was able to fix these warnings and get the same output by breaking out a separate `aStream print:` call.

Being new to Pharo I'm not sure if this is the best idiomatic way to implement it. But I think it's preferable to have an approach that doesn't result in any warnings (unless the code to do so is worse for readers' understanding, and it's worth the warnings)