### PR TITLE
Use openInHand consistently in LOGame instructions

### DIFF
--- a/Chapters/FirstApplication/FirstApplication.pillar
+++ b/Chapters/FirstApplication/FirstApplication.pillar
@@ -609,7 +609,7 @@ the easiest thing to do is to close the debugger window, destroy the running
 instance of the game (with the halo ==CMD-Alt-Shift== and click), and create a
 new one.
 
-Execute ==LOGame new openInWorld== again because if you use the old game
+Execute ==LOGame new openInHand== again because if you use the old game
 instance it will still contain the block with the old logic.
 
 Now the game should work properly... or nearly so. If we happen to move the


### PR DESCRIPTION
At the start of 4.16 it says "type `LOGame new openInHand`. Then after fixing the bug it says "Execute `LOGame new openInWorld` again"—but "again" isn't quite correct because that's the first time that command was executed.

I don't think it's intentional to send two different `openIn…` messages; I think one or the other is intended. `openInHand` is probably better as `openInWorld` opens the game under the Pharo menu bar for me.

This PR changes the second message to `openInHand` to match.